### PR TITLE
Make setup script executable

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-set -e
-npm ci
+set -xe
+
+# Install dependencies and capture output to a log file
+npm ci > setup.log 2>&1


### PR DESCRIPTION
## Summary
- make `.codex/setup.sh` executable in git
- log setup commands via `set -xe` and redirect output to `setup.log`

## Testing
- `npm ci` *(setup script)*
